### PR TITLE
Host Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@
 <div align="center">
     <table>
         <tr>
-            <td align="center"><a href="https://github.com/prykdev"><img src="https://avatars.githubusercontent.com/prykdev" width=150px height=150px /></a></br> <h4 style="color:white;">@ prykdev</h4>
-            <td align="center"><a href="https://github.com/akshatnema"><img src="https://avatars.githubusercontent.com/akshatnema" width=150px height=150px /></a></br> <h4 style="color:white;">@ akshatnema</h4>
-            <td align="center"><a href="https://github.com/ghulamyazdani"><img src="https://avatars.githubusercontent.com/ghulamyazdani" width=150px height=150px /></a></br> <h4 style="color:white;">@ ghulamyazdani</h4>
-            <td align="center"><a href="https://github.com/JOS-RE"><img src="https://avatars.githubusercontent.com/JOS-RE" width=150px height=150px /></a></br> <h4 style="color:white;">@ JOS-RE</h4>
-            <td align="center"><a href="https://github.com/pixan198"><img src="https://avatars.githubusercontent.com/pixan198" width=150px height=150px /></a></br> <h4 style="color:white;">@ pixan198</h4>
-            <td align="center"><a href="https://github.com/Harsha200105"><img src="https://avatars.githubusercontent.com/Harsha200105" width=150px height=150px /></a></br> <h4 style="color:white;">@ Harsha200105</h4>
+            <td align="center"><a href="https://github.com/prykdev"><img src="https://avatars.githubusercontent.com/prykdev" width=150px height=150px /></a></br> <h4 style="color:white;">&nbsp;&nbsp;&nbsp;@prykdev&nbsp;&nbsp;&nbsp;</h4>
+            <td align="center"><a href="https://github.com/akshatnema"><img src="https://avatars.githubusercontent.com/akshatnema" width=150px height=150px/></a></br> <h4 style="color:white;">&nbsp;&nbsp;@akshatnema&nbsp;</h4>
+            <td align="center"><a href="https://github.com/ghulamyazdani"><img src="https://avatars.githubusercontent.com/ghulamyazdani" width=150px height=150px/></a></br> <h4 style="color:white;">@ghulamyazdani</h4>
+            <td align="center"><a href="https://github.com/JOS-RE"><img src="https://avatars.githubusercontent.com/JOS-RE" width=150px height=150px/></a></br> <h4 style="color:white;white-space: pre;">&nbsp;&nbsp;&nbsp;&nbsp;@JOS&#x2011;RE&nbsp;&nbsp;&nbsp;</h4>
+            <td align="center"><a href="https://github.com/pixan198"><img src="https://avatars.githubusercontent.com/pixan198" width=150px height=150px/></a></br> <h4 style="color:white;">&nbsp;&nbsp;@pixan198&nbsp;&nbsp;&nbsp;</h4>
+            <td align="center"><a href="https://github.com/Harsha200105"><img src="https://avatars.githubusercontent.com/Harsha200105" width=150px height=150px/></a></br> <h4 style="color:white;">@Harsha200105&nbsp;</h4>
         </tr>
     </table>
 </div>


### PR DESCRIPTION
### 🤔 Issue:
The display of `readme.md` is changed in GitHub due to its compact window size.. 
### 🪲 Bug:
From my own observation alone:  
The images are sized properly using CSS, but when the window size is squeezed vertically then the individual box size are altered resulting in sizing problem.  
This is due to the headings below[h4 tags], they are responsible for the sizing of the div rather than the images.
### 🛠️ Simple fix: 
Equalize the length of all the strings by adding spaces, specifically by adding `&nbsp;`  
Now the images look more alike than before.
### 📁 Repository updates:
Created a new branch `readme`
Updated `readme.md`
Commit `ebbaa2f`
### 🖼️ Fix Preview:
Clicking below redirects you to [Imgur](https://imgur.com) post where you can compare the visual changes on Desktop as well as Phone.
[Host Images Preview](https://imgur.com/a/dQr30H2)
### 👤Fix by:
[@treasure363](https://github.com/treasure363)